### PR TITLE
Prepare for release v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/kubernetes v1.21.1
 	kmodules.xyz/client-go v0.0.0-20210617233340-13d22e91512b
 	kmodules.xyz/custom-resources v0.0.0-20210618003440-c6bb400da153
-	kubedb.dev/apimachinery v0.19.0-rc.0
+	kubedb.dev/apimachinery v0.19.0
 )
 
 replace go.mongodb.org/mongo-driver => github.com/appscode/mongo-go-driver v1.4.0-beta2.0.20210223075318-951c8933c59c

--- a/go.sum
+++ b/go.sum
@@ -1249,8 +1249,8 @@ kmodules.xyz/openshift v0.0.0-20210618001443-f2507caa512f/go.mod h1:8E5ckbd1KMNm
 kmodules.xyz/prober v0.0.0-20210618020259-5836fb959027/go.mod h1:H4NcvS1RQxeXtQONALbU6r9OT3Xa7cMhfamX/k9t9wo=
 kmodules.xyz/resource-metadata v0.5.7/go.mod h1:Jdi7zBXRwwFTOR0CxwKxqJhsDVIilhrgNipPjnKLyrs=
 kmodules.xyz/webhook-runtime v0.0.0-20210618013329-0accb929102b/go.mod h1:MFZFmJk9IXNHwq8JlF/mukwBDbopFQj4swaB2MWHc/U=
-kubedb.dev/apimachinery v0.19.0-rc.0 h1:Nd8Us1RQ8Vr4jgwJc4tCy7YTz0GGafN1Hy2PfYb3n0s=
-kubedb.dev/apimachinery v0.19.0-rc.0/go.mod h1:EsDnTm5D9VBJiZjBfx9JMDgOldvtKcRP7Y52AFzsMTg=
+kubedb.dev/apimachinery v0.19.0 h1:sK3d5qAK/CCheYtKmlvtXxjTPqxlZBY75cVaI5fXIvE=
+kubedb.dev/apimachinery v0.19.0/go.mod h1:EsDnTm5D9VBJiZjBfx9JMDgOldvtKcRP7Y52AFzsMTg=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -944,7 +944,7 @@ kmodules.xyz/custom-resources/crds
 kmodules.xyz/monitoring-agent-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20210618005544-5217a24765da
 kmodules.xyz/offshoot-api/api/v1
-# kubedb.dev/apimachinery v0.19.0-rc.0
+# kubedb.dev/apimachinery v0.19.0
 ## explicit
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2021.06.23
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>